### PR TITLE
protect against undefined specificationGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Protect against race condition that makes specificationGroups undefined.
 
 ## [0.0.1] - 2019-10-08
 ### Added

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -464,3 +464,20 @@ test('dont show item with displayValue condition not provided', () => {
   getByText(/On Sale/)
   expect(queryByText(/Demo/)).toBeFalsy()
 })
+
+test('do not break if specificationgroups is undefined', () => {
+  const { queryByText } = renderComponent({
+    specificationsOptions: [{
+      specificationName: 'On Sale',
+      displayValue: 'SPECIFICATION_NAME',
+      visibleWhen: 'True',
+    },
+    {
+      specificationName: 'Demo',
+    }],
+    specificationGroupName: "allSpecifications",
+    product: getProduct({ specificationGroups: undefined }),
+  })
+
+  expect(queryByText(/On Sale/)).toBeFalsy()
+})

--- a/react/components/BaseSpecificationBadges.tsx
+++ b/react/components/BaseSpecificationBadges.tsx
@@ -49,7 +49,7 @@ const getVisibleBadges = (
   if (!product) {
     return []
   }
-  const { specificationGroups } = product
+  const { specificationGroups = [] } = product
   const group = specificationGroups.find(propEq('name', groupName))
 
   if (!group) {

--- a/react/typings/vtex.product-context.d.ts
+++ b/react/typings/vtex.product-context.d.ts
@@ -19,7 +19,7 @@ interface SpecificationGroup {
 }
 
 interface Product {
-  specificationGroups: SpecificationGroup[]
+  specificationGroups?: SpecificationGroup[]
 }
 
 declare module 'vtex.product-context/useProduct' {


### PR DESCRIPTION
#### What problem is this solving?

![image](https://user-images.githubusercontent.com/284515/66675031-d2c69a00-ec3a-11e9-85ec-0a1f1f634cd5.png)

If the categoryTree or beenfits query finish faster than the productQuery, a product will be inserted in the context that does not have many fields, like the specificationGroups.

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
