### PR TITLE
Handle products that doesnt have specificationGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Handle products that doesn't have `specificationGroups`.
 
 ## [0.0.1] - 2019-10-08
 ### Added

--- a/react/components/BaseSpecificationBadges.tsx
+++ b/react/components/BaseSpecificationBadges.tsx
@@ -49,7 +49,7 @@ const getVisibleBadges = (
   if (!product) {
     return []
   }
-  const { specificationGroups } = product
+  const specificationGroups = product.specificationGroups || []
   const group = specificationGroups.find(propEq('name', groupName))
 
   if (!group) {


### PR DESCRIPTION
#### What problem is this solving?

It shows the following error if you open this product:
storecomponents.myvtex.com/admin/cms/site-editor

![image](https://user-images.githubusercontent.com/284515/66674901-867b5a00-ec3a-11e9-829a-71d75b5cf474.png)

#### How should this be manually tested?

[Fixed workspace](https://breno--storecomponents.myvtex.com/)

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
