### PR TITLE
Also consider null specification groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Component breaking if `specificationGroups` is `null`.
 
 ## [0.1.0] - 2020-03-10
 ### Fixed

--- a/react/components/BaseSpecificationBadges.tsx
+++ b/react/components/BaseSpecificationBadges.tsx
@@ -49,8 +49,8 @@ const getVisibleBadges = (
   if (!product) {
     return []
   }
-  const { specificationGroups = [] } = product
-  const group = specificationGroups.find(propEq('name', groupName))
+  const { specificationGroups } = product
+  const group = specificationGroups?.find(propEq('name', groupName))
 
   if (!group) {
     return []


### PR DESCRIPTION
#### What problem is this solving?

Prevent component from breaking if `specificationGroups` is `null`.

#### How should this be manually tested?
Compare:

1)  https://badge--eriksbikeshop.myvtex.com/search?_query=Specialized%20RBX%20Swat%20Shorts%202019&utm_source=sdgh
2) https://kiwi--eriksbikeshop.myvtex.com/search?_query=Specialized%20RBX%20Swat%20Shorts%202019&utm_source=sdgh

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).
