### PR TITLE
Add more options to the `allSpecification` group list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.3.0] - 2020-11-04
+
+### Changed
+- Updated the specification groups list source, so it might have more options available.
+
+### Added
+- CSS Handles to specification value.
+
 ## [0.2.0] - 2020-09-29
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-specification-badges",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "title": "Product Specification Badges",
   "description": "Display Product Specification Badges",
   "defaultLocale": "pt-BR",

--- a/react/components/BaseSpecificationBadges.tsx
+++ b/react/components/BaseSpecificationBadges.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { propEq, concat } from 'ramda'
+import { propEq } from 'ramda'
 import slugify from '../modules/slug'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 
@@ -100,7 +100,7 @@ const getVisibleBadges = (
     const optionsBadges = specificationsOptions.map(option =>
       getValidSpecificationForCondition(option, group.specifications))
       .filter(Boolean) as VisibleSpecification[]
-    badges = badges.concat(optionsBadges)
+    badges = badge(optionsBadges)
   }
 
   return badges

--- a/react/components/BaseSpecificationBadges.tsx
+++ b/react/components/BaseSpecificationBadges.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { propEq } from 'ramda'
+import { propEq, concat } from 'ramda'
 import slugify from '../modules/slug'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 
@@ -40,6 +40,29 @@ interface VisibleSpecification {
   displayValue: Condition['displayValue']
 }
 
+const getSpecificationGroupsList = (product: Product | undefined): SpecificationGroup[] => {
+  const { properties, specificationGroups } = product || {};
+
+  const allSpecifications = properties?.map(specification => ({
+    name: specification.name,
+    values: specification.values,
+    originalName: specification.name
+  })) || []
+
+  const specificationGroupsList = specificationGroups?.filter(specificationGroup =>
+    (specificationGroup.name !== "allSpecifications")
+  ) || []
+
+  return [
+    ...specificationGroupsList,
+    {
+      name: "allSpecifications",
+      originalName: "allSpecifications",
+      specifications: allSpecifications
+    }
+  ]
+}
+
 const getVisibleBadges = (
   product: Product | undefined,
   baseCondition: ConditionWithName,
@@ -49,7 +72,8 @@ const getVisibleBadges = (
   if (!product) {
     return []
   }
-  const { specificationGroups } = product
+
+  const specificationGroups = getSpecificationGroupsList(product);
 
   const group = specificationGroups?.find(propEq('originalName', groupName))
 

--- a/react/components/BaseSpecificationBadges.tsx
+++ b/react/components/BaseSpecificationBadges.tsx
@@ -100,7 +100,7 @@ const getVisibleBadges = (
     const optionsBadges = specificationsOptions.map(option =>
       getValidSpecificationForCondition(option, group.specifications))
       .filter(Boolean) as VisibleSpecification[]
-    badges = badge(optionsBadges)
+    badges = badges.concat(optionsBadges)
   }
 
   return badges

--- a/react/package.json
+++ b/react/package.json
@@ -34,5 +34,5 @@
   "vtexTestTools": {
     "defaultLocale": "pt-BR"
   },
-  "version": "0.2.0"
+  "version": "0.3.0"
 }

--- a/react/typings/vtex.product-context.d.ts
+++ b/react/typings/vtex.product-context.d.ts
@@ -11,14 +11,17 @@ interface SelectedItem {
 interface Specification {
   name: string
   values: [string]
+  originalName?: string
 }
 
 interface SpecificationGroup {
   name: string
+  originalName?: string
   specifications: Specification[]
 }
 
 interface Product {
+  properties?: Specification[]
   specificationGroups?: SpecificationGroup[]
 }
 


### PR DESCRIPTION
#### What problem is this solving?
Currently the component doesn't consider all of the product specifications due to the data structure that comes from the `product: Product`, once it uses the `product.specificationGroups` list but there's the `product.properties` list which has all of the product specifications.

So the aim here is use `product.properties` list (transformed/mapped) as the `allSpecifications` list
 
<!--- What is the motivation and context for this change? -->

#### How to test it?

[Workspace](https://badges--tokstokio.myvtex.com/)

#### Screenshots or example usage:

So now it's possible to match any of the product specification.

![Screen Shot 2020-11-05 at 15 16 02](https://user-images.githubusercontent.com/26178791/98280252-e5182200-1f79-11eb-956c-01ebcc64777d.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/dsKnRuALlWsZG/giphy.gif)
