### PR TITLE
fix: specificationGroups with empty array for valid product properties

### DIFF
--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -117,7 +117,7 @@ test('show names inside group that meet conditions array', () => {
           name: 'PromoExclusion',
           originalName: 'PromoExclusion',
           values: ['1'],
-        }
+        },
       ],
     },
     {

--- a/react/components/BaseSpecificationBadges.tsx
+++ b/react/components/BaseSpecificationBadges.tsx
@@ -26,7 +26,7 @@ const checkConditionForSpecification = (condition: Condition, specification: Spe
 
 const getValidSpecificationForCondition = (condition: ConditionWithName, specifications: Specification[]) => {
   const { displayValue, specificationName } = condition
-  const specification = specifications.find(propEq('originalName', specificationName))
+  const specification = specifications.find(propEq('name', specificationName))
   if (!specification) {
     return null
   }
@@ -46,20 +46,18 @@ const getVisibleBadges = (
   groupName: string,
   specificationsOptions: BaseProps['specificationsOptions']
 ) => {
+  
   if (!product) {
     return []
   }
-  const { specificationGroups } = product
+
+  const { specificationGroups, properties } = product
 
   const group = specificationGroups?.find(propEq('originalName', groupName))
 
-  if (!group) {
-    return []
-  }
-
   let badges = [] as VisibleSpecification[]
 
-  if (baseCondition.visibleWhen && baseCondition.displayValue) {
+  if (baseCondition.visibleWhen && baseCondition.displayValue && group) {
     const { specificationName } = baseCondition
     const specifications =
       specificationName ? group.specifications.filter(propEq('originalName', specificationName)) : group.specifications
@@ -72,11 +70,11 @@ const getVisibleBadges = (
     }).filter(Boolean) as VisibleSpecification[]
   }
 
-  if (specificationsOptions) {
+  if (specificationsOptions && properties) {
     const optionsBadges = specificationsOptions.map(option =>
-      getValidSpecificationForCondition(option, group.specifications))
+      getValidSpecificationForCondition(option, properties))
       .filter(Boolean) as VisibleSpecification[]
-    badges = badges.concat(optionsBadges)
+    badges = badges.concat(optionsBadges)    
   }
 
   return badges

--- a/react/components/BaseSpecificationBadges.tsx
+++ b/react/components/BaseSpecificationBadges.tsx
@@ -26,7 +26,7 @@ const checkConditionForSpecification = (condition: Condition, specification: Spe
 
 const getValidSpecificationForCondition = (condition: ConditionWithName, specifications: Specification[]) => {
   const { displayValue, specificationName } = condition
-  const specification = specifications.find(propEq('name', specificationName))
+  const specification = specifications.find(propEq('originalName', specificationName)) || specifications.find(propEq('name', specificationName))
   if (!specification) {
     return null
   }
@@ -70,9 +70,10 @@ const getVisibleBadges = (
     }).filter(Boolean) as VisibleSpecification[]
   }
 
-  if (specificationsOptions && properties) {
+  if (specificationsOptions && (properties || group)) {
+    const specifications = group ? group.specifications : properties
     const optionsBadges = specificationsOptions.map(option =>
-      getValidSpecificationForCondition(option, properties))
+      getValidSpecificationForCondition(option, specifications))
       .filter(Boolean) as VisibleSpecification[]
     badges = badges.concat(optionsBadges)    
   }

--- a/react/package.json
+++ b/react/package.json
@@ -29,7 +29,7 @@
     "graphql": "^15.0.0",
     "prettier": "^1.18.2",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "vtexTestTools": {
     "defaultLocale": "pt-BR"

--- a/react/typings/vtex.product-context.d.ts
+++ b/react/typings/vtex.product-context.d.ts
@@ -20,6 +20,7 @@ interface SpecificationGroup {
 
 interface Product {
   specificationGroups?: SpecificationGroup[]
+  properties: Specification[]
 }
 
 declare module 'vtex.product-context/useProduct' {

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5984,10 +5984,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.7.3:
   version "3.9.3"


### PR DESCRIPTION
#### What problem is this solving?

Exemplifying the following thread
https://vtex.slack.com/archives/GDQRXF8J1/p1605660787025700

#### How to test it?

[Workspace](https://iespinoza--alssports.myvtex.com/vortex-hoodie-performance-mens/p?skuId=794958)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/13649073/99473855-35a05f80-292a-11eb-8318-1f472fb1b0fb.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/dSeVDdzx1kri7GYWJG/giphy.gif)
